### PR TITLE
Increase jailer wait timeout to 60 seconds

### DIFF
--- a/pkg/jailer/jailer.go
+++ b/pkg/jailer/jailer.go
@@ -46,7 +46,7 @@ func CreateJail(name string) error {
 
 	logrus.Debugf("Creating jail for %v", name)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "/usr/bin/jailer.sh", name)


### PR DESCRIPTION
On host machines which are running more slowly than expected due to factors outside our control (such as anti-virus, high CPU usage, older hardware) Rancher can be prevented from starting due to the current 10 second timeout.

I'd like to propose this change to increase the timeout to 60 seconds.